### PR TITLE
Feat/access key control variable

### DIFF
--- a/examples/example.tf
+++ b/examples/example.tf
@@ -14,6 +14,7 @@ module "iam-user" {
   pgp_key                 = ""
   password_length         = 20
   password_reset_required = true
+  # create_access_key = false
 }
 
 data "aws_iam_policy_document" "default" {

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -14,7 +14,7 @@ module "iam-user" {
   pgp_key                 = ""
   password_length         = 20
   password_reset_required = true
-  # create_access_key = false
+  create_access_key       = true
 }
 
 data "aws_iam_policy_document" "default" {

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "aws_iam_user" "default" {
 }
 
 resource "aws_iam_access_key" "default" {
-  count   = var.enabled ? 1 : 0
+  count   = var.enabled && var.create_access_key ? 1 : 0
   user    = aws_iam_user.default.*.name[0]
   pgp_key = var.pgp_key
   status  = var.status

--- a/variables.tf
+++ b/variables.tf
@@ -153,3 +153,9 @@ variable "ssh_public_key" {
   description = "The SSH public key. The public key must be encoded in ssh-rsa format or PEM format"
 }
 
+variable "create_access_key" {
+  type        = bool
+  default     = true
+  description = "Whether to create an access key for iam role"
+
+}


### PR DESCRIPTION
## what
* Added a new control variable (create_access_key) to enable or disable creation of the AWS IAM access key.

## why
* Allows users to manage whether access keys should be created, improving security and flexibility.